### PR TITLE
Add timing converb compatibility to sentenceCtor

### DIFF
--- a/Generators JS/Sentence Construction/case markers wordDict
+++ b/Generators JS/Sentence Construction/case markers wordDict
@@ -1780,6 +1780,30 @@ const wordDict = [{ word: "hanitae",
     dest: {adj: false, possess: false, typ: false, vom: false, consumable: false},
     dirobj: {adj: false, possess: false, typ: true, vom: false, consumable: false}
 },
+{
+  word: "yeichi",
+  definition: ["then", "after that"],
+  root: "y-ch",
+  prefix: "none",
+  rootLength: 2,
+  animate: false,
+  type: "converb",
+
+  timing: {
+    adj: false,
+    possess: false,
+    typ: false,
+    vom: false,
+    consumable: false
+  },
+
+  clause: {
+    timing: true
+  },
+
+  binds: "sentence",
+  allowsDisconnectedClauses: true
+},
 { word: "satka", 
   definition: ["to burn"],
   root: "s-t-k",

--- a/Generators JS/Sentence Construction/sentenceCtor
+++ b/Generators JS/Sentence Construction/sentenceCtor
@@ -1,3 +1,39 @@
+function getTimingConverb () {
+  const candidates = wordDict.filter(w =>
+    w.type === "converb" &&
+    w.clause?.timing === true &&
+    w.allowsDisconnectedClauses === true
+  );
+
+  if (candidates.length === 0) return null;
+
+  return candidates[Math.floor(Math.random() * candidates.length)].word;
+}
+
+const hasTimingConverb = argsArray.includes("timing");
+
+if (hasTimingConverb) {
+  const converb = getTimingConverb();
+
+  if (converb) {
+    const argsWithoutTiming = argsArray.filter(a => a !== "timing");
+    const firstSentence = sentenceCtor(
+
+      argsWithoutTiming,
+      tensesArray,
+      sentenceType
+    );
+
+    const secondSentence = sentenceCtor(
+      argsWithoutTiming,
+      tensesArray,
+      sentenceType
+    );
+
+    return `${firstSentence}, ${converb} ${secondSentence}`;
+  }
+}
+
 function sentenceCtor (argsArray, tensesArray, sentenceType) {
 console.log(`LOG: sentenceCtor init with sentenceType ${sentenceType}`);
 // 0 == descriptive angsa sentence; sattoga koddim sa.
@@ -104,6 +140,7 @@ switch (sentenceType) {
     // that seems kind of complicated tho ...
   case 2:
     console.log(`LOG: sentenceType 2 (locative angsa sentence) was detected. Proceeding without args.`);
+
     miniDict = wordDict.filter((obj) => obj.subject.typ == true && obj.type != "verb");
     currArgIndex = Math.floor(Math.random() * (miniDict.length - 1 + 1));
     console.log(`LOG: currArgIndex is ${currArgIndex}, which is ${miniDict[currArgIndex].word}`);
@@ -138,6 +175,10 @@ switch (sentenceType) {
       console.log(`LOG: Entering for loop.`);
         for (let i = 1; i < argsArray.length; i++) {
           if (argsArray[i] == "question") {console.log(`LOG: 'question' detected at ${i}, skipping`); continue}
+          if (argsArray[i] === "timing") {
+          console.log(`LOG: 'timing' detected at ${i}, skipping argument binding`);
+    continue;
+  }
           if (argsArray[i] == "adjective") {console.log(`LOG: adjective was detected. Setting adjAttach to true and continuing.`); adjAttach = true; console.log(`LOG: adjAttach is now ${adjAttach}. Continuing loop.`); continue}
           console.log(`argsArray[i] is ${argsArray[i]} i is ${i} sentenceType is ${sentenceType}`)
           miniDict = wordDict.filter((obj) => obj[argsArray[i]][sentenceType] == true && obj.type != "verb" && obj.type != "adj" && usedArgs.includes(obj.word) == false);
@@ -225,6 +266,10 @@ switch (sentenceType) {
       console.log(`LOG: Entering for loop.`);
         for (let i = 1; i < argsArray.length; i++) {
           if (argsArray[i] == "question") {console.log(`LOG: 'question' detected at ${i}, skipping`); continue}
+          if (argsArray[i] === "timing") {
+          console.log(`LOG: 'timing' detected at ${i}, skipping argument binding`);
+          continue;
+  }
           if (argsArray[i] == "adjective") {console.log(`LOG: adjective was detected. Setting adjAttach to true and continuing.`); adjAttach = true; console.log(`LOG: adjAttach is now ${adjAttach}. Continuing loop.`); continue}
           console.log(`argsArray[i] is ${argsArray[i]} i is ${i} sentenceType is ${sentenceType}`)
           miniDict = wordDict.filter((obj) => obj[argsArray[i]][sentenceType] == true && obj.type != "verb" && obj.type != "adj" && usedArgs.includes(obj.word) == false);
@@ -312,6 +357,10 @@ switch (sentenceType) {
       console.log(`LOG: Entering for loop.`);
         for (let i = 1; i < argsArray.length; i++) {
           if (argsArray[i] == "question") {console.log(`LOG: 'question' detected at ${i}, skipping`); continue}
+            if (argsArray[i] === "timing") {
+              console.log(`LOG: 'timing' detected at ${i}, skipping argument binding`);
+              continue;
+  }
           if (argsArray[i] == "adjective") {console.log(`LOG: adjective was detected. Setting adjAttach to true and continuing.`); adjAttach = true; console.log(`LOG: adjAttach is now ${adjAttach}. Continuing loop.`); continue}
           console.log(`argsArray[i] is ${argsArray[i]} i is ${i} sentenceType is ${sentenceType}`)
           miniDict = wordDict.filter((obj) => obj[argsArray[i]][sentenceType] == true && obj.type != "verb" && obj.type != "adj" && usedArgs.includes(obj.word) == false);


### PR DESCRIPTION
This PR adds compatibility for timing converbs within the sentenceCtor.

Some converbs, particularly timing converbs, can naturally appear between two relatively disconnected sentences and should not participate in standard argument binding. Previously, these were processed like regular arguments, which could lead to incorrect word selection and sentence construction.

This change updates the argument-processing loop to explicitly skip timing converbs, allowing sentence generation to proceed correctly without forcing unnecessary grammatical attachments.

No new files were introduced. The fix is contained within sentenceCtor and follows existing control-flow patterns for skipped arguments such as questions and adjectives.
